### PR TITLE
Add to "RIA Services":

### DIFF
--- a/docs/documentation/3rd-party-libraries/ria-services.html
+++ b/docs/documentation/3rd-party-libraries/ria-services.html
@@ -182,6 +182,14 @@ Install-Package OpenRiaServices.EntityFramework.EF4 -Version 4.6.0
 <pre><code>  Install-Package OpenRiaServices.Endpoints -Version 5.0.0-preview0003
 </code></pre>
 </li>
+
+<li><p>Projects that are referenced by Server-side</p>
+Remove reference to <code>System.Data.Entity</code> and replace that with nuget package:
+<pre><code>  Install-Package EntityFramework -Version 6.0.1
+</code></pre>
+Replace <code>using System.Data.</code> with <code>using System.Data.Entity.Core.</code>
+</li>
+
 </ul>
 <p>As you can see for Silverlight projects versions <strong>4.6.0</strong> are used because version <strong>5.0.0</strong> drops Silverlight support.
 For OpenSilver project version <strong>5.0.0-preview0003</strong> is used. This is required for code generation and everything to work fine.</p>


### PR DESCRIPTION
Projects that are referenced by Server-side

Remove reference to System.Data.Entity and replace that with nuget package:
  Install-Package EntityFramework -Version 6.0.1
Replace using System.Data. with using System.Data.Entity.Core.